### PR TITLE
Some improvement

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -61,6 +61,7 @@ final class MyNode : ASDisplayNode {
   private let textNode8 = makeTextNode("Hello!")
   private let backgroundNode = ASDisplayNode()
   
+  private let textNodes = [makeTextNode("Hello!"), makeTextNode("Hello")]
   override init() {
     super.init()
     
@@ -95,6 +96,8 @@ final class MyNode : ASDisplayNode {
         textNode8
           .padding([.vertical], 4)
           .background(backgroundNode)
+        
+        textNodes
         
       }
     }    

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -84,6 +84,9 @@ final class MyNode : ASDisplayNode {
           textNode2
         }
         textNode3
+          .styling { (s) in
+            s.alignSelf = .end
+        }
         
         ASLayoutSpec()
         

--- a/TextureSwiftSupport/MethodChain.swift
+++ b/TextureSwiftSupport/MethodChain.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 muukii. All rights reserved.
 //
 
-import Foundation
 import UIKit
+import AsyncDisplayKit
 
 public enum Edge: Int8, CaseIterable {
   
@@ -101,4 +101,16 @@ extension _ASLayoutElementType {
   public func overlay<Overlay: _ASLayoutElementType>(_ overlayContent: Overlay) -> OverlayLayout<Overlay, Self> {
     OverlayLayout(content: { self }, overlay: { overlayContent })
   }
+}
+
+// MARK: - Styled
+
+extension _ASLayoutElementType {
+  
+  public func styling(_ styling: @escaping (ASLayoutElementStyle) -> Void) -> StyledLayout<Self> {
+    StyledLayout(styling: styling) {
+      self
+    }
+  }
+  
 }

--- a/TextureSwiftSupport/SpecBuilder.swift
+++ b/TextureSwiftSupport/SpecBuilder.swift
@@ -15,7 +15,7 @@ public protocol _ASLayoutElementType {
     content
   }
   
-  public static func buildBlock(_ content: _ASLayoutElementType...) -> MultiLayout {
+  public static func buildBlock(_ content: _ASLayoutElementType?...) -> MultiLayout {
     MultiLayout(content)
   }
   

--- a/TextureSwiftSupport/SpecBuilder.swift
+++ b/TextureSwiftSupport/SpecBuilder.swift
@@ -289,6 +289,26 @@ public struct VSpacerLayout : _ASLayoutElementType {
   }
 }
 
+public struct StyledLayout<Content>: _ASLayoutElementType where Content : _ASLayoutElementType {
+  
+  let styling: (ASLayoutElementStyle) -> Void
+  let content: Content
+  
+  public init(styling: @escaping (ASLayoutElementStyle) -> Void, content: () -> Content) {
+    self.styling = styling
+    self.content = content()
+  }
+  
+  public func make() -> [ASLayoutElement] {
+    let elems = content.make()
+    elems.forEach { (elem) in
+      styling(elem.style)
+    }
+    return elems
+  }
+  
+}
+
 
 extension Array: _ASLayoutElementType where Element: _ASLayoutElementType {
   

--- a/TextureSwiftSupport/SpecBuilder.swift
+++ b/TextureSwiftSupport/SpecBuilder.swift
@@ -288,3 +288,14 @@ public struct VSpacerLayout : _ASLayoutElementType {
     ]
   }
 }
+
+
+extension Array: _ASLayoutElementType where Element: _ASLayoutElementType {
+  
+  public func make() -> [ASLayoutElement] {
+    self.flatMap {
+      $0.make()
+    }
+  }
+  
+}


### PR DESCRIPTION
- [x] Fix non-else if statement:

```swift
VStackLayout {
  if true {
    node1
  }
  node2
}
```

- [x] `[_ASLayoutElementType]` Array support:

```swift
let nodes: [ASDisplayNode] = ...
VStackLayout {
  nodes
}
```

- [x] `.styling` method chain support:

```swift
VStackLayout {
   textNode1
   textNode2
      .background(background)
      .styling { (s) in
          s.alignSelf = .end
      }
}
```