### PR TITLE
Flatten padding

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -62,6 +62,9 @@ final class MyNode : ASDisplayNode {
   private let backgroundNode = ASDisplayNode()
   private var optionalNode: ASDisplayNode?
   
+  private let baseBoxNode = makeBoxNode(.red)
+  private let overlayBoxNode = makeBoxNode(.blue)
+  
   override init() {
     super.init()
     
@@ -98,6 +101,18 @@ final class MyNode : ASDisplayNode {
           .padding([.vertical], 4)
           .background(backgroundNode)
           .flexGrow(1)
+        
+        VStackLayout {
+          baseBoxNode
+            .preferredSize(.init(width: 100, height: 100))
+        }
+        .overlay(
+          overlayBoxNode
+            .preferredSize(.init(width: 20, height: 20))
+            .padding(.top, 8)
+            .padding(UIEdgeInsets(top: 0, left: 0, bottom: .infinity, right: .infinity))
+        )
+        
         
       }
     }    

--- a/TextureSwiftSupport/MethodChain.swift
+++ b/TextureSwiftSupport/MethodChain.swift
@@ -49,12 +49,47 @@ public enum Edge: Int8, CaseIterable {
   
 }
 
+@inline(__always)
+fileprivate func makeInsets(_ padding: CGFloat) -> UIEdgeInsets {
+  .init(top: padding, left: padding, bottom: padding, right: padding)
+}
+
+@inline(__always)
+fileprivate func makeInsets(_ edges: Edge.Set, _ padding: CGFloat) -> UIEdgeInsets {
+  var insets = UIEdgeInsets.zero
+  
+  if edges.contains(.top) {
+    insets.top = padding
+  }
+  
+  if edges.contains(.left) {
+    insets.left = padding
+  }
+  
+  if edges.contains(.bottom) {
+    insets.bottom = padding
+  }
+  
+  if edges.contains(.right) {
+    insets.right = padding
+  }
+  return insets
+}
+
+fileprivate func combineInsets(_ lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> UIEdgeInsets {
+  var base = lhs
+  base.top += rhs.top
+  base.right += rhs.right
+  base.left += rhs.left
+  base.bottom += rhs.bottom
+  return base
+}
 
 // MARK: - Padding
 extension _ASLayoutElementType {
   
   public func padding(_ padding: CGFloat) -> InsetLayout<Self> {
-    InsetLayout(insets: .init(top: padding, left: padding, bottom: padding, right: padding)) {
+    InsetLayout(insets: makeInsets(padding)) {
       self
     }
   }
@@ -66,29 +101,34 @@ extension _ASLayoutElementType {
   }
   
   public func padding(_ edges: Edge.Set, _ padding: CGFloat) -> InsetLayout<Self> {
-    
-    var insets = UIEdgeInsets.zero
-    
-    if edges.contains(.top) {
-      insets.top = padding
-    }
-    
-    if edges.contains(.left) {
-      insets.left = padding
-    }
-    
-    if edges.contains(.bottom) {
-      insets.bottom = padding
-    }
-    
-    if edges.contains(.right) {
-      insets.right = padding
-    }
-    
-    return InsetLayout(insets: insets) {
+            
+    return InsetLayout(insets: makeInsets(edges, padding)) {
       self
     }
   }
+  
+}
+
+extension InsetLayout {
+  
+  public func padding(_ padding: CGFloat) -> Self {
+    var _self = self
+    _self.insets = combineInsets(_self.insets, rhs: makeInsets(padding))
+    return _self
+  }
+  
+  public func padding(_ edgeInsets: UIEdgeInsets) -> Self {
+    var _self = self
+    _self.insets = combineInsets(_self.insets, rhs: edgeInsets)
+    return _self
+  }
+  
+  public func padding(_ edges: Edge.Set, _ padding: CGFloat) -> Self {
+    var _self = self
+    _self.insets = combineInsets(_self.insets, rhs: makeInsets(edges, padding))
+    return _self
+  }
+  
 }
 
 // MARK: - Background

--- a/TextureSwiftSupport/SpecBuilder.swift
+++ b/TextureSwiftSupport/SpecBuilder.swift
@@ -295,7 +295,7 @@ public struct CenterLayout<Content> : _ASLayoutElementType where Content : _ASLa
 public struct InsetLayout<Content> : _ASLayoutElementType where Content : _ASLayoutElementType {
   
   public let content: Content
-  public let insets: UIEdgeInsets
+  public var insets: UIEdgeInsets
   
   public init(insets: UIEdgeInsets, content: () -> Content) {
     self.content = content()


### PR DESCRIPTION
This PR makes sure flatten nested InsetLayout<Node>.
Until now, padding operator makes wrapping up with InsetLayout everytime we use.
From now, we can define the padding by focusing on readability with flattening.

## Before

```
node
  .padding(...)
  .padding(...)
  .padding(...)
```

```
node => InsetLayout<InsetLayout<InsetLayout<MyNode>>>
```

## After

```
node => InsetLayout<MyNode>
```
